### PR TITLE
Nerd fonts v3 fix and removed the need for env variable to display distro!

### DIFF
--- a/.starship/starship.toml
+++ b/.starship/starship.toml
@@ -5,19 +5,23 @@ add_newline = true
 
 # Change the default prompt format
 format = """\
-[╭╴](238)$env_var\
+[╭╴](238)$os\
 $all[╰─](238)$character"""
 
 # Change the default prompt characters
 [character]
-success_symbol = "[](238)"
-error_symbol = "[](238)"
+success_symbol = "[](238)"
+error_symbol = "[](238)"
 
-# Shows an icon that should be included by zshrc script based on the distribution or os
-[env_var.STARSHIP_DISTRO]
-format = '[$env_value](bold white)'  # removed space between distro and rest for pwsh
-variable = "STARSHIP_DISTRO"
+# No need for env variables as starship provides a way to show your current distro
+[os]
+format ='[$symbol](bold white)'   
 disabled = false
+
+[os.symbols]
+Windows = " "
+Arch = "󰣇"
+Ubuntu = ""
 
 # Shows the username
 [username]
@@ -30,13 +34,13 @@ show_always = false
 [directory]
 truncation_length = 3
 truncation_symbol = "…/"
-home_symbol = " ~"
+home_symbol = "󰋞 ~"
 read_only_style = "197"
 read_only = "  "
 format = "at [$path]($style)[$read_only]($read_only_style) "
 
 [git_branch]
-symbol = " "
+symbol = "󰊢 "
 format = "on [$symbol$branch]($style) "
 truncation_length = 4
 truncation_symbol = "…/"
@@ -51,10 +55,10 @@ untracked = " "
 ahead = "⇡${count}"
 diverged = "⇕⇡${ahead_count}⇣${behind_count}"
 behind = "⇣${count}"
-stashed = " "
+stashed = "󰏗 "
 modified = " "
 staged = '[++\($count\)](green)'
-renamed = "襁 "
+renamed = "󰖷 "
 deleted = " "
 
 [terraform]
@@ -70,11 +74,11 @@ format = "via [ $context](bold blue) "
 format = "via [ $version](bold purple) "
 
 [python]
-symbol = " "
+symbol = "󰌠 "
 python_binary = "python3"
 
 [nodejs]
-format = "via [ $version](bold green) "
+format = "via [󰎙 $version](bold green) "
 disabled = true
 
 [ruby]


### PR DESCRIPTION
Nerd fonts released the [3.0.0](https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.0.0) version which dropped support for `nf-mdi-*` class names, this makes some icons to render improperly (related to this [issue](https://github.com/ChristianLempa/dotfiles-win/issues/5))

Also, there's no need to set an env variable to display the current distro, starship already provides a [way](https://starship.rs/config/#os) to display the current distro, so i changed that too!